### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # What is DigitalFate?
 
+[![smithery badge](https://smithery.ai/badge/@DanyelaMB/DigitalFate)](https://smithery.ai/server/@DanyelaMB/DigitalFate)
+
 DigitalFate provides an advanced, enterprise-ready framework for orchestrating LLM calls, agents, and computer-based tasks in a cost-efficient manner. It delivers reliable systems, scalability, and a task-oriented architecture to handle real-world applications effectively.
 
 **Key Features:**
@@ -27,6 +29,15 @@ DigitalFate provides an advanced, enterprise-ready framework for orchestrating L
 
 ## Installation
 
+### Installing via Smithery
+
+To install DigitalFate for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@DanyelaMB/DigitalFate):
+
+```bash
+npx -y @smithery/cli install @DanyelaMB/DigitalFate --client claude
+```
+
+### Manual Installation
 ```bash
 pip install digitalfate
 ```

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,21 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - openaiApiKey
+      - anthropicApiKey
+    properties:
+      openaiApiKey:
+        type: string
+        description: The API key for OpenAI services.
+      anthropicApiKey:
+        type: string
+        description: The API key for Anthropic services.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({command: 'docker', args: ['run', '--rm', '-e', `OPENAI_API_KEY=${config.openaiApiKey}`, '-e', `ANTHROPIC_API_KEY=${config.anthropicApiKey}`, 'digitalfate'], env: {}})


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over WebSockets so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@DanyelaMB/DigitalFate?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂